### PR TITLE
CCM - New taxonomy added in asset_taxonomy.ttl

### DIFF
--- a/taxonomy/asset_taxonomy.ttl
+++ b/taxonomy/asset_taxonomy.ttl
@@ -140,3 +140,8 @@ cx-taxo:Asset a skos:Concept ;
         skos:broader cx-taxo:Asset;
         skos:prefLabel "Receive ID Based Comment for DCM"@en;
         skos:definition "API to receive an ID Based Comment in DCM context".
+
+    cx-taxo:CCMAPI a skos:Concept;
+        skos:broader cx-taxo:Asset;
+        skos:prefLabel "CompanyCertificateManagementNotificationApi"@en;
+        skos:definition "API to enable Catena-X Members to send and receive Notifications in regards with the Company Certificates Data Exchange".


### PR DESCRIPTION

## WHAT

Added a new taxonomy for CCMAPI 

## WHY

To align with the standard definition of a data asset for the Company's certificate management notification API.

## FURTHER NOTES

none

Closes # <-- none
